### PR TITLE
cancelled 5/26 office hours

### DIFF
--- a/_data/cal.yml
+++ b/_data/cal.yml
@@ -12,8 +12,8 @@
           popupText: "A weekly call for agencies to get updates from the DATA Act PMO team and to ask questions. See <a href='https://community.max.gov/download/attachments/254050873/DATA%20Act%20Resource%20Guide%201-11-2016.pdf?api=v2' target='_blank'>this document</a> for call in information."
         - title: "5/19 Office Hours"
           popupText: "A weekly call for agencies to get updates from the DATA Act PMO team and to ask questions. See <a href='https://community.max.gov/download/attachments/254050873/DATA%20Act%20Resource%20Guide%201-11-2016.pdf?api=v2' target='_blank'>this document</a> for call in information."
-        - title: "5/26 Office Hours"
-          popupText: "A weekly call for agencies to get updates from the DATA Act PMO team and to ask questions. See <a href='https://community.max.gov/download/attachments/254050873/DATA%20Act%20Resource%20Guide%201-11-2016.pdf?api=v2' target='_blank'>this document</a> for call in information."
+        - title: "5/26 Office Hours CANCELLED"
+          popupText: "Office Hours are cancelled this week due to <a href='http://www.datacoalition.org/data-act-summit-data-demo-day-2016/' target='_blank'>2016 DATA Act Summit</a>."
 
 
   


### PR DESCRIPTION
@kaitlin Added link to DATA Act summit, but you can just delete pop up if you want since it is not sponsored by us.
